### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alabaster==0.7.12
 Babel==2.6.0
-bleach==3.1.1
+bleach==3.1.2
 chardet==3.0.4
 Click==7.0
 cloudpickle==0.6.1


### PR DESCRIPTION
Bumps bleach from 3.1.1 to 3.1.2 due to security vulnerability with the prior version.